### PR TITLE
Use canvas to draw boxes

### DIFF
--- a/Grid.elm
+++ b/Grid.elm
@@ -1,4 +1,4 @@
-module Grid (Grid, decode, encode, fromList, empty, rotate, stamp, collide, mapToList, clearLines, initPosition) where
+module Grid (Grid, decode, encode, fromList, empty, rotate, stamp, collide, mapToList, clearLines, initPosition, size) where
 import Json.Decode as Decode exposing ((:=))
 import Json.Encode as Encode
 
@@ -99,6 +99,16 @@ clearLines wid grid =
         (newGrid, lines) = clearLines wid (droppedAbove ++ below)
       in
         (newGrid, lines + 1)
+
+
+size : Grid a -> (Int, Int)
+size grid =
+  let
+    (x, y) = List.unzip (List.map .pos grid)
+    dimension d =
+      Maybe.withDefault 0 (List.maximum (List.map (\a -> a + 1) d))
+  in
+    (dimension x, dimension y)
 
 
 centerOfMass : Grid a -> (Int, Int)

--- a/Tetriminos.elm
+++ b/Tetriminos.elm
@@ -2,9 +2,9 @@ module Tetriminos (random) where
 import Grid exposing (Grid)
 import Array exposing (Array)
 import Random
+import Color exposing (Color)
 
-
-random : Random.Seed -> (Grid String, Random.Seed)
+random : Random.Seed -> (Grid Color, Random.Seed)
 random seed =
   let
     (i, seed') = Random.generate (Random.int 0 (List.length tetriminos - 1)) seed
@@ -13,15 +13,15 @@ random seed =
     (tetrimino, seed')
 
 
-tetriminos : List (Grid String)
+tetriminos : List (Grid Color)
 tetriminos =
   List.map
     (uncurry Grid.fromList)
-    [ ("#3cc7d6", [(0, 0), (1, 0), (2, 0), (3, 0)])
-    , ("#fbb414", [(0, 0), (1, 0), (0, 1), (1, 1)])
-    , ("#b04497", [(1, 0), (0, 1), (1, 1), (2, 1)])
-    , ("#3993d0", [(0, 0), (0, 1), (1, 1), (2, 1)])
-    , ("#ed652f", [(2, 0), (0, 1), (1, 1), (2, 1)])
-    , ("#95c43d", [(1, 0), (2, 0), (0, 1), (1, 1)])
-    , ("#e84138", [(0, 0), (1, 0), (1, 1), (2, 1)])
+    [ ((Color.rgb 60 199 214), [(0, 0), (1, 0), (2, 0), (3, 0)])
+    , ((Color.rgb 251 180 20), [(0, 0), (1, 0), (0, 1), (1, 1)])
+    , ((Color.rgb 176 68 151), [(1, 0), (0, 1), (1, 1), (2, 1)])
+    , ((Color.rgb 57 147 208), [(0, 0), (0, 1), (1, 1), (2, 1)])
+    , ((Color.rgb 237 101 47), [(2, 0), (0, 1), (1, 1), (2, 1)])
+    , ((Color.rgb 149 196 61), [(1, 0), (2, 0), (0, 1), (1, 1)])
+    , ((Color.rgb 232 65 56), [(0, 0), (1, 0), (1, 1), (2, 1)])
     ]


### PR DESCRIPTION
This is a modification of elm-flatris that uses canvas to render the main grid and the next tetrimino in the sidebar. Would be awesome to compare the performance of both. Chrome shows 60fps to me in both cases, but still maybe there are some differences.
